### PR TITLE
'BugFix: issue of removing in use version.' ~ 13/06/21 @ 23:41:57

### DIFF
--- a/TERRA.sh
+++ b/TERRA.sh
@@ -4,6 +4,7 @@
 
 TERRAINPUT1=${1}
 VERSION=${2}
+forceSet="false"
 
 terraLogo() {
     printf "\n__________________________________________    _____ \n\\__    ___/\\_   _____/\\______   \\______   \\  /  _  \\ \n  |    |    |    __)_  |       _/|       _/ /  /_\\  \\ \n  |    |    |        \\ |    |   \\|    |   \\/    |    \\ \n  |____|   /_______  / |____|_  /|____|_  /\\____|__  / \n                   \\/         \\/        \\/         \\/ \n\n"
@@ -77,21 +78,30 @@ terraInstall() {
 }
 
 terraUninstall() {
+    if [[ $(terraform --version | grep "${VERSION}") == "${VERSION}" ]]; then
+        forceSet="true"
+        terraSet
+    fi
     sudo update-alternatives --remove terraform /usr/local/terraform/${VERSION}/terraform
 }
 
 terraSet() {
-    terraList
-    TERRALISTCOUNT=$((($TERRALISTCOUNT - 1)))
-    for (( c=0; c<=$TERRALISTCOUNT; c++ ))
-    do
-        if [[ ${TERRALIST[${c}]} == *"/${VERSION}/"* ]]; then
-            TERRALISTCOUNT="$(((${c} + 1)))"
-            echo "$TERRALISTCOUNT" | sudo update-alternatives --config terraform  &> /dev/null
-            terraform --version
-            break;
-        fi
-    done
+    if [[ ${forceSet} == "true" ]]; then
+        echo "0" | sudo update-alternatives --config terraform  &> /dev/null
+        forceSet="false"
+    else
+        terraList
+        TERRALISTCOUNT=$((($TERRALISTCOUNT - 1)))
+        for (( c=0; c<=$TERRALISTCOUNT; c++ ))
+        do
+            if [[ ${TERRALIST[${c}]} == *"/${VERSION}/"* ]]; then
+                TERRALISTCOUNT="$(((${c} + 1)))"
+                echo "$TERRALISTCOUNT" | sudo update-alternatives --config terraform  &> /dev/null
+                terraform --version
+                break;
+            fi
+        done
+    fi
 }
 
 terraHelp() {


### PR DESCRIPTION
Bug Fix: The user when trying to remove a Terraform version, particularly if the version is in use by the utility, the process would provide a warning. To get around this issue, the app will now force a change to the auto (0) option. This option will enable dynamic change to the user's latest (highest priority) version. If the latest version is was to be removed, the option automatically assigns the one that came after. This will not affect other aspects of the application as it is localized to the uninstall and set processes via a variable (on/off).